### PR TITLE
Fixing Jenkins Build errors

### DIFF
--- a/drone_assets/package.xml
+++ b/drone_assets/package.xml
@@ -10,6 +10,7 @@
   <license>MIT</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <depend>gazebo_ros</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/drone_circuit_assets/CMakeLists.txt
+++ b/drone_circuit_assets/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(catkin REQUIRED COMPONENTS)
 
 catkin_package()
 
-install(DIRECTORY ../drone_assets/models worlds
+install(DIRECTORY worlds
  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
@@ -26,7 +26,7 @@ configure_file (
     assets-setup.sh
 )
 
-install(DIRECTORY ../drone_assets/models worlds launch
+install(DIRECTORY worlds launch
 DESTINATION gazebo)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/assets-setup.sh 
 DESTINATION gazebo)

--- a/drone_wrapper/CMakeLists.txt
+++ b/drone_wrapper/CMakeLists.txt
@@ -16,7 +16,6 @@ catkin_python_setup()
 catkin_package()
 
 install(PROGRAMS
-	src/drone_tello_class.py
 	scripts/play_python_code
 	scripts/load_parameters
 	DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/rqt_drone_teleop/package.xml
+++ b/rqt_drone_teleop/package.xml
@@ -16,7 +16,7 @@
 	<depend>rqt_gui</depend>
 	<depend>rqt_gui_py</depend>
 	<depend>sensor_msgs</depend>
-	<depend>python-rospkg</depend>
+	<depend>python3-rospkg</depend>
 	<depend>roslib</depend>
 	<depend>drone_wrapper</depend>
 

--- a/rqt_ground_robot_teleop/package.xml
+++ b/rqt_ground_robot_teleop/package.xml
@@ -15,7 +15,7 @@
 	<depend>rqt_gui</depend>
 	<depend>rqt_gui_py</depend>
 	<depend>sensor_msgs</depend>
-	<depend>python-rospkg</depend>
+	<depend>python3-rospkg</depend>
 	<depend>roslib</depend>
 
 	<!-- The export tag contains other, unspecified, tags -->

--- a/tello_driver/CMakeLists.txt
+++ b/tello_driver/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
-catkin_python_setup()
 catkin_package()
 
 

--- a/tello_driver/setup.py
+++ b/tello_driver/setup.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
-
-d = generate_distutils_setup(
-    packages=['tello_driver'],
-    package_dir={'': 'src'}
-)
-setup(**d)


### PR DESCRIPTION
## DroneWrapper
Log output: https://build.ros.org/job/Nbin_uF64__drone_wrapper__ubuntu_focal_amd64__binary/16/console

Main issue:
```
08:11:24 CMake Error at cmake_install.cmake:60 (file):
08:11:24   file INSTALL cannot find
08:11:24   "/tmp/binarydeb/ros-noetic-drone-wrapper-1.4.1/src/drone_tello_class.py":
08:11:24   No such file or directory.
```

**Solution**: removing reference to non-existing file 

## Drone Circuit Assets
Log output: https://build.ros.org/job/Nbin_uF64__drone_circuit_assets__ubuntu_focal_amd64__binary/5/console

Main issue:
```
08:08:07 CMake Error at cmake_install.cmake:56 (file):
08:08:07   file INSTALL cannot find
08:08:07   "/tmp/binarydeb/ros-noetic-drone-circuit-assets-1.4.1/../drone_assets/models":
08:08:07   No such file or directory.
```

**Solution**: Removing reference to drone_assets models

## Tello Driver
Log output: https://build.ros.org/job/Nbin_ufv8_uFv8__tello_driver__ubuntu_focal_arm64__binary/7/console

Main issue:
```
08:25:13 error: package directory 'src/tello_driver' does not exist
08:25:13 CMake Error at catkin_generated/safe_execute_install.cmake:4 (message):
08:25:13   
08:25:13   execute_process(/tmp/binarydeb/ros-noetic-tello-driver-1.4.1/obj-aarch64-linux-gnu/catkin_generated/python_distutils_install.sh)
08:25:13   returned error code
```

**Solution**: Tello driver is not used as python module anymore, removing setup.py

## RQT Drone Teleop & RQT Ground Robot Teleop
Log output: https://build.ros.org/job/Nbin_uF64__rqt_drone_teleop__ubuntu_focal_amd64__binary/148/console
Log output: https://build.ros.org/job/Nbin_uF64__rqt_ground_robot_teleop__ubuntu_focal_amd64__binary/147/console

Main issue:
```
14:11:18 KeyError: "The cache has no package named 'python-rospkg'"
14:11:18 Build step 'Execute shell' marked build as failure
```

**Solution**: updating `python-rospkg` to `python3-rospkg`

## Drone Assets
Log output: https://build.ros.org/job/Nbin_uF64__drone_assets__ubuntu_focal_amd64__binary/6/console

Main issue:
```
08:07:53 CMake Error at CMakeLists.txt:6 (find_package):
08:07:53   By not providing "Findgazebo.cmake" in CMAKE_MODULE_PATH this project has
08:07:53   asked CMake to find a package configuration file provided by "gazebo", but
08:07:53   CMake did not find one.
08:07:53 
08:07:53   Could not find a package configuration file provided by "gazebo" with any
08:07:53   of the following names:
08:07:53 
08:07:53     gazeboConfig.cmake
08:07:53     gazebo-config.cmake
08:07:53 
08:07:53   Add the installation prefix of "gazebo" to CMAKE_PREFIX_PATH or set
08:07:53   "gazebo_DIR" to a directory containing one of the above files.  If "gazebo"
08:07:53   provides a separate development package or SDK, be sure it has been
08:07:53   installed.
```

**Solution**: Adding `gazebo_ros` dependency to drone_assets package.xml